### PR TITLE
Drop obsolete crypto, use stronger privsep

### DIFF
--- a/docker-openssh-server/sshd_config
+++ b/docker-openssh-server/sshd_config
@@ -7,13 +7,19 @@ Port 23
 #ListenAddress ::
 #ListenAddress 0.0.0.0
 Protocol 2
+
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
+
+# Privilege separation is turned on for security
+UsePrivilegeSeparation sandbox
+
+# Enforce cryptographically-sound primitives
+# Based off https://wiki.mozilla.org/Security/Guidelines/OpenSSH#Modern_.28OpenSSH_6.7.2B.29
+KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600
@@ -27,9 +33,7 @@ LogLevel INFO
 LoginGraceTime 120
 PermitRootLogin no
 StrictModes yes
-
-RSAAuthentication yes
-PubkeyAuthentication yes
+AuthenticationMethods publickey
 AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 AllowUsers client
@@ -42,26 +46,6 @@ RhostsRSAAuthentication no
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
 #IgnoreUserKnownHosts yes
-
-# To enable empty passwords, change to yes (NOT RECOMMENDED)
-PermitEmptyPasswords no
-
-# Change to yes to enable challenge-response passwords (beware issues with
-# some PAM modules and threads)
-ChallengeResponseAuthentication no
-
-# Change to no to disable tunnelled clear text passwords
-PasswordAuthentication no
-
-# Kerberos options
-#KerberosAuthentication no
-#KerberosGetAFSToken no
-#KerberosOrLocalPasswd yes
-#KerberosTicketCleanup yes
-
-# GSSAPI options
-#GSSAPIAuthentication no
-#GSSAPICleanupCredentials yes
 
 X11Forwarding no
 X11DisplayOffset 10


### PR DESCRIPTION
- Explicitely only allow pubkey-based authentication, rather than disabling everything else: `AuthenticationMethods publickey`
- Do not advertise (EC)DSA host keys: DSA should be dropped, and if your client is recent enough to support ECDSA it likely supports Ed25519 (which is mostly ECDSA on a safe curve); consider dropping RSA if practical.
- Use stronger privsep: `sandbox` not only drops privilege, but also use a seccomp-based sandbox.
- Require strong symmetric cryptography to be used
  - Only allow MACs in encrypt-then-MAC construction (SSH predates the understanding that EtM is provably secure, whereas E&M and MtE are vulnerable).
  - If possible, use an authenticated-encryption mode, otherwise fallback to counter mode (+ EtM).
  - Perform key exchange on Curve25519 (preferred) or on as large a NIST curve as supported.